### PR TITLE
✨ fix contact email site index

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -304,7 +304,7 @@
       <button type="submit" style="background:#e44c65;color:#fff;border:none;padding:0.7rem;border-radius:8px;font-size:1rem;cursor:pointer;">ارسال پیام</button>
     </form>
     <div class="contact-info" style="text-align:center;margin-bottom:1rem;">
-      <p>ایمیل: info@opscalesolution@gmail.com</p>
+      <p>ایمیل: opscalesolution@gmail.com</p>
       <p>وبسایت: https://opscale.ir</p>
   <p>شبکه‌های اجتماعی: <a href="http://linkedin.com/company/opscale" target="_blank">LinkedIn</a> | <a href="https://opscale-talk.slack.com" target="_blank">Slack</a> | <a href="https://x.com/OpScaleSolutions" target="_blank">X (Twitter)</a></p>
     </div>


### PR DESCRIPTION
Update contact info on the homepage to correct the public email
address. Replace the internal/support alias (info@opscalesolution@gmail.com)
with the official public address (opscalesolution@gmail.com) to avoid
misdirected messages and improve consistency with other contact channels.
This ensures incoming inquiries reach the intended inbox and matches the
branding on the site.