### PR TITLE
fix: correct social account names and X handle

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Active contributor to CNCF and open-source projects. Committed to knowledge shar
 
 - **Email:** [solutions@opscale.ir](mailto:opscalesolution@gmail.com)
 - **Website:** [opscale.ir](https://opscale.ir)
-- **LinkedIn:** [OpScale Solutions](http://linkedin.com/company/opscale)
+- **LinkedIn:** [OpScale Solution](http://linkedin.com/company/opscale)
 - **Slack:** [OpScale Community](https://opscale-talk.slack.com)
-- **X (Twitter):** [@OpScaleSolutions](https://x.com/OpScaleSolutions)
+- **X (Twitter):** [@OpScaleSolution](https://x.com/OpScaleSolution)
 
 ## License
 

--- a/site/index.html
+++ b/site/index.html
@@ -306,7 +306,7 @@
     <div class="contact-info" style="text-align:center;margin-bottom:1rem;">
       <p>ایمیل: opscalesolution@gmail.com</p>
       <p>وبسایت: https://opscale.ir</p>
-  <p>شبکه‌های اجتماعی: <a href="http://linkedin.com/company/opscale" target="_blank">LinkedIn</a> | <a href="https://opscale-talk.slack.com" target="_blank">Slack</a> | <a href="https://x.com/OpScaleSolutions" target="_blank">X (Twitter)</a></p>
+  <p>شبکه‌های اجتماعی: <a href="http://linkedin.com/company/opscale" target="_blank">LinkedIn</a> | <a href="https://opscale-talk.slack.com" target="_blank">Slack</a> | <a href="https://x.com/OpScaleSolution" target="_blank">X (Twitter)</a></p>
     </div>
     <a href="#contact" class="cta">درخواست جلسه مشاوره رایگان</a>
   </section>


### PR DESCRIPTION
Update LinkedIn and X (Twitter) display names and the X account URL
to use the singular "OpScale Solution" instead of "OpScale Solutions".
Fix the X link in the site footer to point to https://x.com/OpScaleSolution.

These changes align public-facing text and links with the project's
official account naming to avoid broken or inconsistent references.