### PR TITLE
docs: fix Slack URL in README and site index

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Active contributor to CNCF and open-source projects. Committed to knowledge shar
 - **Email:** [solutions@opscale.ir](mailto:opscalesolution@gmail.com)
 - **Website:** [opscale.ir](https://opscale.ir)
 - **LinkedIn:** [OpScale Solution](http://linkedin.com/company/opscale)
-- **Slack:** [OpScale Community](https://opscale-talk.slack.com)
+- **Slack:** [OpScale Community](https://opscalesolution.slack.com)
 - **X (Twitter):** [@OpScaleSolution](https://x.com/OpScaleSolution)
 
 ## License

--- a/site/index.html
+++ b/site/index.html
@@ -306,7 +306,7 @@
     <div class="contact-info" style="text-align:center;margin-bottom:1rem;">
       <p>ایمیل: opscalesolution@gmail.com</p>
       <p>وبسایت: https://opscale.ir</p>
-  <p>شبکه‌های اجتماعی: <a href="http://linkedin.com/company/opscale" target="_blank">LinkedIn</a> | <a href="https://opscale-talk.slack.com" target="_blank">Slack</a> | <a href="https://x.com/OpScaleSolution" target="_blank">X (Twitter)</a></p>
+  <p>شبکه‌های اجتماعی: <a href="http://linkedin.com/company/opscale" target="_blank">LinkedIn</a> | <a href="https://opscalesolution.slack.com" target="_blank">Slack</a> | <a href="https://x.com/OpScaleSolution" target="_blank">X (Twitter)</a></p>
     </div>
     <a href="#contact" class="cta">درخواست جلسه مشاوره رایگان</a>
   </section>


### PR DESCRIPTION
Update Slack links from the old workspace URL to the current
opscalesolution.slack.com address in README.md and site/index.html.
This corrects broken/inaccessible Slack links so users can reach the
OpScale community channel from the website and documentation.