### PR TITLE
docs: remove email from MohammadReza Taleghani entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Kubernetes, Docker, Helm, ArgoCD, Prometheus, Grafana, Loki, ELK, GitLab CI, Lin
 Our team includes:
 - **علیرضا طالقانی** ([GitHub](https://github.com/AliRezaTaleghani))
 - **مجتبی طالقانی** ([GitHub](https://github.com/mojitaleghani))
-- **محمدرضا طالقانی** ([LinkedIn](https://www.linkedin.com/in/mohammad-reza-taleghani-b6684049/), mrt.taleghani@gmail.com)
+- **محمدرضا طالقانی** ([LinkedIn](https://www.linkedin.com/in/mohammad-reza-taleghani-b6684049))
 
 Certified: CKA, CKAD, CKS, CNCF Member
 


### PR DESCRIPTION
Remove the personal email address from MohammadReza Taleghani's team
entry in README.md. The change keeps the LinkedIn link but omits the
email to avoid exposing personal contact details in the public repo.