### PR TITLE
feat(infra migrate small-tier docs to-first setup

### DIFF
--- a/site/solution.html
+++ b/site/solution.html
@@ -189,27 +189,27 @@
     <script>
         const tierData = {
             small: {
-                title: "سطح ۱: شرکت کوچک (تا ۱۰۰ هزار مشتری)",
-                goal: "ایجاد یک زیرساخت پایدار و قابل اتکا برای شروع قدرتمند.",
-                hardware: `
-                    <div class="overflow-x-auto">
-                        <table class="w-full rtl-table border-collapse">
-                            <thead>
-                                <tr class="bg-slate-100">
-                                    <th class="p-3 font-bold uppercase text-slate-600 border border-slate-200">نوع منبع</th>
-                                    <th class="p-3 font-bold uppercase text-slate-600 border border-slate-200">تعداد</th>
-                                    <th class="p-3 font-bold uppercase text-slate-600 border border-slate-200">مشخصات (هر واحد)</th>
-                                    <th class="p-3 font-bold uppercase text-slate-600 border border-slate-200">توضیحات</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr><td class="p-3 border border-slate-200">VMs (Production)</td><td class="p-3 border border-slate-200">۲</td><td class="p-3 border border-slate-200">۸ هسته CPU، ۱۶ گیگابایت RAM</td><td class="p-3 border border-slate-200">Redundancy برای تضمین عدم قطعی سرویس.</td></tr>
-                                <tr><td class="p-3 border border-slate-200">VM (Dev/Staging)</td><td class="p-3 border border-slate-200">۱</td><td class="p-3 border border-slate-200">۴ هسته CPU، ۸ گیگابایت RAM</td><td class="p-3 border border-slate-200">محیط ایزوله برای توسعه و تست.</td></tr>
-                                <tr><td class="p-3 border border-slate-200">VM (Infra Tools)</td><td class="p-3 border border-slate-200">۱</td><td class="p-3 border border-slate-200">۴ هسته CPU، ۸ گیگابایت RAM</td><td class="p-3 border border-slate-200">بستری اختصاصی برای GitLab.</td></tr>
-                                <tr><td class="p-3 border border-slate-200">فضای ذخیره‌سازی</td><td class="p-3 border border-slate-200">۵۰۰ گیگابایت</td><td class="p-3 border border-slate-200">-</td><td class="p-3 border border-slate-200">فضای بلاک برای پایگاه‌های داده.</td></tr>
-                            </tbody>
-                        </table>
-                    </div>`,
+                    title: "سطح ۱: شرکت کوچک (تا ۱۰۰ هزار مشتری)",
+                    goal: "ایجاد یک زیرساخت پایدار و قابل اتکا برای شروع قدرتمند، مبتنی بر Kubernetes.",
+                    hardware: `
+                        <div class=\"overflow-x-auto\">
+                            <table class=\"w-full rtl-table border-collapse\">
+                                <thead>
+                                    <tr class=\"bg-slate-100\">
+                                        <th class=\"p-3 font-bold uppercase text-slate-600 border border-slate-200\">نوع منبع</th>
+                                        <th class=\"p-3 font-bold uppercase text-slate-600 border border-slate-200\">تعداد</th>
+                                        <th class=\"p-3 font-bold uppercase text-slate-600 border border-slate-200\">مشخصات (هر واحد)</th>
+                                        <th class=\"p-3 font-bold uppercase text-slate-600 border border-slate-200\">توضیحات</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr><td class=\"p-3 border border-slate-200\">Kubernetes Master</td><td class=\"p-3 border border-slate-200\">۱</td><td class=\"p-3 border border-slate-200\">۸ هسته CPU، ۱۶ گیگابایت RAM</td><td class=\"p-3 border border-slate-200\">مدیریت کلاستر و کنترل پنل.</td></tr>
+                                    <tr><td class=\"p-3 border border-slate-200\">Kubernetes Worker</td><td class=\"p-3 border border-slate-200\">۳</td><td class=\"p-3 border border-slate-200\">۸ هسته CPU، ۱۶ گیگابایت RAM</td><td class=\"p-3 border border-slate-200\">اجرای سرویس‌ها و اپلیکیشن‌ها.</td></tr>
+                                    <tr><td class=\"p-3 border border-slate-200\">VM (GitLab)</td><td class=\"p-3 border border-slate-200\">۱</td><td class=\"p-3 border border-slate-200\">۴ هسته CPU، ۸ گیگابایت RAM</td><td class=\"p-3 border border-slate-200\">GitLab خارج از کلاستر برای مدیریت کد.</td></tr>
+                                    <tr><td class=\"p-3 border border-slate-200\">فضای ذخیره‌سازی</td><td class=\"p-3 border border-slate-200\">۵۰۰ گیگابایت</td><td class=\"p-3 border border-slate-200\">-</td><td class=\"p-3 border border-slate-200\">فضای بلاک برای پایگاه‌های داده و اپلیکیشن‌ها.</td></tr>
+                                </tbody>
+                            </table>
+                        </div>`,
                 domain: `
                     <h4 class="text-lg font-bold mt-6 mb-2">ساختار دامنه:</h4>
                     <ul class="list-disc list-inside space-y-1 text-slate-600">
@@ -219,23 +219,23 @@
             },
             medium: {
                 title: "سطح ۲: شرکت متوسط (تا ۱ میلیون مشتری)",
-                goal: "پیاده‌سازی یک زیرساخت پویا و با قابلیت رشد بالا.",
+                goal: "پیاده‌سازی یک زیرساخت پویا و با قابلیت رشد بالا، مبتنی بر Kubernetes.",
                 hardware: `
-                    <div class="overflow-x-auto">
-                        <table class="w-full rtl-table border-collapse">
+                    <div class=\"overflow-x-auto\">
+                        <table class=\"w-full rtl-table border-collapse\">
                             <thead>
-                                <tr class="bg-slate-100">
-                                    <th class="p-3 font-bold uppercase text-slate-600 border border-slate-200">نوع منبع</th>
-                                    <th class="p-3 font-bold uppercase text-slate-600 border border-slate-200">تعداد</th>
-                                    <th class="p-3 font-bold uppercase text-slate-600 border border-slate-200">مشخصات (هر Node)</th>
-                                    <th class="p-3 font-bold uppercase text-slate-600 border border-slate-200">توضیحات</th>
+                                <tr class=\"bg-slate-100\">
+                                    <th class=\"p-3 font-bold uppercase text-slate-600 border border-slate-200\">نوع منبع</th>
+                                    <th class=\"p-3 font-bold uppercase text-slate-600 border border-slate-200\">تعداد</th>
+                                    <th class=\"p-3 font-bold uppercase text-slate-600 border border-slate-200\">مشخصات (هر واحد)</th>
+                                    <th class=\"p-3 font-bold uppercase text-slate-600 border border-slate-200\">توضیحات</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr><td class="p-3 border border-slate-200">Kubernetes Cluster</td><td class="p-3 border border-slate-200">حداقل ۳ Node</td><td class="p-3 border border-slate-200">۱۶ هسته CPU، ۳۲ گیگابایت RAM</td><td class="p-3 border border-slate-200">مقیاس‌پذیری خودکار با افزایش کاربران.</td></tr>
-                                <tr><td class="p-3 border border-slate-200">VM (Dev/Staging)</td><td class="p-3 border border-slate-200">۲</td><td class="p-3 border border-slate-200">۸ هسته CPU، ۱۶ گیگابایت RAM</td><td class="p-3 border border-slate-200">محیط مستقل برای تست و توسعه موازی.</td></tr>
-                                <tr><td class="p-3 border border-slate-200">VM (Infra Tools)</td><td class="p-3 border border-slate-200">۲</td><td class="p-3 border border-slate-200">۸ هسته CPU، ۱۶ گیگابایت RAM</td><td class="p-3 border border-slate-200">Redundancy برای پایداری ابزارهای زیرساخت.</td></tr>
-                                <tr><td class="p-3 border border-slate-200">فضای ذخیره‌سازی</td><td class="p-3 border border-slate-200">۱ ترابایت</td><td class="p-3 border border-slate-200">-</td><td class="p-3 border border-slate-200">فضای بلاک با قابلیت افزایش خودکار.</td></tr>
+                                <tr><td class=\"p-3 border border-slate-200\">Kubernetes Master</td><td class=\"p-3 border border-slate-200\">۳</td><td class=\"p-3 border border-slate-200\">۱۶ هسته CPU، ۳۲ گیگابایت RAM</td><td class=\"p-3 border border-slate-200\">High Availability برای مدیریت کلاستر.</td></tr>
+                                <tr><td class=\"p-3 border border-slate-200\">Kubernetes Worker</td><td class=\"p-3 border border-slate-200\">۷</td><td class=\"p-3 border border-slate-200\">۱۶ هسته CPU، ۳۲ گیگابایت RAM</td><td class=\"p-3 border border-slate-200\">اجرای سرویس‌ها و اپلیکیشن‌ها با مقیاس‌پذیری بالا.</td></tr>
+                                <tr><td class=\"p-3 border border-slate-200\">VM (GitLab)</td><td class=\"p-3 border border-slate-200\">۲</td><td class=\"p-3 border border-slate-200\">۸ هسته CPU، ۱۶ گیگابایت RAM</td><td class=\"p-3 border border-slate-200\">GitLab خارج از کلاستر با Redundancy.</td></tr>
+                                <tr><td class=\"p-3 border border-slate-200\">فضای ذخیره‌سازی</td><td class=\"p-3 border border-slate-200\">۱ ترابایت</td><td class=\"p-3 border border-slate-200\">-</td><td class=\"p-3 border border-slate-200\">فضای بلاک با قابلیت افزایش خودکار.</td></tr>
                             </tbody>
                         </table>
                     </div>`,


### PR DESCRIPTION
Update the "small" tier in solution to recommend a Kubernetes-
centric architecture and adjust hardware rows to reflect cluster
components instead of plain VMs. Replace generic production/dev/infra
VM entries with Kubernetes Master and Worker nodes, add a dedicated
VM entry for GitLab outside the cluster, and clarify storage usage.
Also refine the goal text to state the Kubernetes-based infrastructure.

This change modernizes the guidance for small companies (up to
100k customers) to encourage container orchestration, improve
scalability and service isolation, and make operational roles
(clear cluster control plane, workers, and external CI host)
more explicit.