### PR TITLE
✨ feat(readme): add promotional video link and note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
-
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![CNCF Member](https://img.shields.io/badge/CNCF-Member-blueviolet.svg)](https://www.cncf.io/)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-Certified%20Experts-blue.svg)](https://www.cncf.io/certification/)
+
+## Promotional Video
+
+[🎬 Watch OpScale Solutions Promo (Muted)](./site/OpScaleAdv.mp4)
+
+> The video is provided without sound by default for a distraction-free preview.
 
 **OpScale Solutions | Cloud Native & Kubernetes Experts**
 


### PR DESCRIPTION
Add a muted promotional video to the README with a direct link
to site/OpScaleAdv.mp4 so visitors can quickly preview OpScale
Solutions. Include a short explanatory note that the video is
provided without sound by default for a distraction-free preview.

This improves the project's marketing presence and helps users
see a concise visual introduction without causing audio disruption.