### PR TITLE
✨ feat: remove video from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 [![CNCF Member](https://img.shields.io/badge/CNCF-Member-blueviolet.svg)](https://www.cncf.io/)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-Certified%20Experts-blue.svg)](https://www.cncf.io/certification/)
 
-## Promotional Video
-
-[🎬 Watch OpScale Solutions Promo (Muted)](./site/OpScaleAdv.mp4)
-
-> The video is provided without sound by default for a distraction-free preview.
-
 **OpScale Solutions | Cloud Native & Kubernetes Experts**
 
 OpScale Solutions specializes in designing, implementing, and supporting scalable cloud-native and on-premise infrastructures with a focus on Kubernetes, CNCF technologies, and open-source best practices.


### PR DESCRIPTION
Remove the embedded promotional video section from README.md to
simplify the project landing content and reduce repository size.
The video link and its note about muted playback are deleted because
the media is not essential to documentation, may increase clone
bandwidth, and can be served externally if needed. This keeps the
README focused on the project's purpose and capabilities.