### PR TITLE
✨ feat(ui): remove redundant contact mailto button

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -382,7 +382,6 @@
                 </div>
             </div>
             <div class="text-center mt-12">
-                                <a href="mailto:contact@opscale.ir" class="bg-blue-600 text-white font-bold py-3 px-8 rounded-lg hover:bg-blue-700 transition text-lg">شروع مشاوره رایگان</a>
                                 <div class="flex justify-center gap-4 mt-8">
                                     <a href="mailto:solutions@opscale.ir" title="ایمیل" class="bg-blue-100 rounded-full p-3 hover:bg-blue-600 hover:text-white transition">
                                         <span class="text-2xl">📧</span>


### PR DESCRIPTION
Remove the duplicated "شروع مشاوره رایگان" mailto button from the
homepage hero section to avoid presenting users with multiple email
links that could cause confusion. The change deletes the hard-coded
contact@opscale.ir anchor, leaving the single solutions@opscale.ir
contact action and the surrounding icon links. This simplifies the UI
and reduces clutter while keeping a clear, single point of contact.