### PR TITLE
✨ feat: update contact email address in footer

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -383,7 +383,7 @@
             </div>
             <div class="text-center mt-12">
                                 <div class="flex justify-center gap-4 mt-8">
-                                    <a href="mailto:solutions@opscale.ir" title="ایمیل" class="bg-blue-100 rounded-full p-3 hover:bg-blue-600 hover:text-white transition">
+                                    <a href="mailto:opscalesolution@gmail.com" title="ایمیل" class="bg-blue-100 rounded-full p-3 hover:bg-blue-600 hover:text-white transition">
                                         <span class="text-2xl">📧</span>
                                     </a>
                                     <a href="http://linkedin.com/company/opscale" title="LinkedIn" class="bg-blue-100 rounded-full p-3 hover:bg-blue-600 hover:text-white transition">


### PR DESCRIPTION
Change the footer mailto link to use the public Gmail address
(opscalesolution@gmail.com) instead of the internal domain
(solutions@opscale.ir). This ensures users clicking the email icon
reach the monitored public inbox for support and inquiries.