### PR TITLE
✨ feat: add og:logo meta tag to site index

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -15,6 +15,7 @@
     <meta property="og:image:secure_url" content="https://opscale.ir/OpScale.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
+    <meta property="og:logo" content="https://opscale.ir/OpScale.png" />
     <meta property="og:video" content="https://opscale.ir/OpScale.mp4">
     <meta property="og:video:secure_url" content="https://opscale.ir/OpScale.mp4">
     <meta property="og:video:type" content="video/mp4">


### PR DESCRIPTION
Add an Open Graph logo meta tag to improve rich link previews
on platforms that can use a dedicated logo field. This helps
social and messaging services display a branded logo alongside
other OG media (image/video), improving recognition and visual
consistency when sharing the site.

File changed:
- site/index.html: insert <meta property="og:logo" ...> to include
  https://opscale.ir/OpScale.png as the site's logo.