### PR TITLE
✨ feat: add favicon and apple-touch-icon to site

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -33,6 +33,10 @@
     <meta name="twitter:player:width" content="1280">
     <meta name="twitter:player:height" content="720">
 
+    <!-- Favicon -->
+    <link rel="icon" type="image/png" href="OpScale.png">
+    <link rel="apple-touch-icon" href="OpScale.png">
+
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>


### PR DESCRIPTION
Add a PNG favicon and an apple-touch-icon to the main site HTML.
Include link tags in the head so browsers and iOS devices display the
site icon (OpScale.png). This improves brand recognition and user
experience when bookmarking or pinning the site.